### PR TITLE
Fixed missing typ module

### DIFF
--- a/challenges.html
+++ b/challenges.html
@@ -137,7 +137,7 @@
       });
 
   </script>
-  <script src="src/modules/filterToggle.js">
+  <script type="module" src="src/modules/filterToggle.js">
 
 
   </script>


### PR DESCRIPTION
Fixed the Uncaught SyntaxError: Unexpected token 'export' by adding typ module on the filterToggel script src